### PR TITLE
Fix  fractal theme path by starting at index 0, not 1

### DIFF
--- a/lib/new-theme/build.js
+++ b/lib/new-theme/build.js
@@ -67,7 +67,7 @@ function prepareRoot(config) {
 
     // Fractal rewrites
     let fractalFileData = fs.readFileSync(fractalConfigFile, 'utf8');
-    result = fractalFileData.replace(/BC__BASE__THEMEDIR/g, config.gulpThemePath.substr(1));
+    result = fractalFileData.replace(/BC__BASE__THEMEDIR/g, config.gulpThemePath.substr(0));
     result = result.replace(/BC__BASE__NAME/g, config.project_title_case);
     result = result.replace(/BC__BASE/g, config.project);
     fs.writeFileSync(fractalConfigFile, result, 'utf8');


### PR DESCRIPTION
I was getting `./eb/themes/custom/longwood/assets/src/scss/app.scss` in the replacement of `BC__BASE__THEMEDIR` in `fractal.js`. This should correct this to `./web/...`.